### PR TITLE
fix usage

### DIFF
--- a/src/main/python/succubus/daemonize.py
+++ b/src/main/python/succubus/daemonize.py
@@ -23,7 +23,8 @@ class Daemon(object):
                  stdout='/dev/null',
                  stderr='/dev/null'):
         if len(sys.argv) == 1:
-            return self.usage()
+            self.param1 = None
+            return
         self.param1 = sys.argv.pop(1)
 
         self.stdin = os.path.abspath(stdin)


### PR DESCRIPTION
There is a flaw in the usage implementation. When using the example provided
in the README, I receive the following output:

```
% ./example.py
Usage: ./example.py {start|stop|restart|status}
Traceback (most recent call last):
  File "./example.py", line 30, in <module>
    main()
  File "./example.py", line 25, in main
    daemon = MyDaemon(pid_file='succubus.pid')
TypeError: __init__() should return None, not 'int'
```

The problem is, that the constructor can not return an integer value. The fix
is to return immediately when there is nothing on the command line and then
echo the usage later, when the user calls `action`.
